### PR TITLE
Added support for defining a base domain via config.json

### DIFF
--- a/src/app/services/window.service.ts
+++ b/src/app/services/window.service.ts
@@ -2,12 +2,14 @@ import { Inject, Injectable } from '@angular/core';
 import { parse } from 'tldts';
 
 import { WINDOW } from '../providers/window.provider';
+import { ConfigService } from './config.service';
 
 @Injectable()
 export class WindowService {
   // eslint-disable-next-line no-useless-constructor
   public constructor(
-    @Inject(WINDOW) private window: Window) {}
+    @Inject(WINDOW) private window: Window,
+    private configService: ConfigService) {}
 
   public getHostname(): string {
     return this.window.location.hostname;
@@ -35,8 +37,17 @@ export class WindowService {
   }
 
   public getSubdomain(): string {
-    const urlParsed = parse(this.window.location.host);
-    return urlParsed.publicSuffix === 'localhost' ? urlParsed.domainWithoutSuffix ?? '' : urlParsed.subdomain;
+    const host = this.window.location.host;
+    const urlParsed = parse(host);
+    if (urlParsed.publicSuffix === 'localhost') {
+      return urlParsed.domainWithoutSuffix ?? '';
+    }
+    const baseDomain = this.configService.getConfig().Domain?.baseDomain;
+    const index = host.indexOf(baseDomain);
+    if (baseDomain && index >= 0) {
+      return host.startsWith(baseDomain) ? '' : host.substring(0, index - 1);
+    }
+    return urlParsed.subdomain;
   }
 
   public getLocalStorage(): Storage {

--- a/src/app/types/configuration/Configuration.ts
+++ b/src/app/types/configuration/Configuration.ts
@@ -16,7 +16,7 @@ import DomainConfiguration from "./DomainConfiguration";
 export interface Configuration {
   Advanced: AdvancedConfiguration;
   Authorization: AuthorizationConfiguration;
-  Domain: DomainConfiguration
+  Domain?: DomainConfiguration
   CentralSystemServer: CentralSystemServerConfiguration;
   Company: CompanyConfiguration;
   Asset: AssetConfiguration;

--- a/src/app/types/configuration/Configuration.ts
+++ b/src/app/types/configuration/Configuration.ts
@@ -11,10 +11,12 @@ import SiteAreaConfiguration from './SiteAreaConfiguration';
 import SiteConfiguration from './SiteConfiguration';
 import TenantConfiguration from './TenantConfiguration';
 import UserConfiguration from './UserConfiguration';
+import DomainConfiguration from "./DomainConfiguration";
 
 export interface Configuration {
   Advanced: AdvancedConfiguration;
   Authorization: AuthorizationConfiguration;
+  Domain: DomainConfiguration
   CentralSystemServer: CentralSystemServerConfiguration;
   Company: CompanyConfiguration;
   Asset: AssetConfiguration;

--- a/src/app/types/configuration/DomainConfiguration.ts
+++ b/src/app/types/configuration/DomainConfiguration.ts
@@ -1,0 +1,3 @@
+export default interface DomainConfiguration {
+  baseDomain?: string;
+}


### PR DESCRIPTION
The addtion allows for the platform to be hosted on a subdomain (or nested subdomains).

e.g. this allows the platform to be hosted on:
`prd01.xyz.com` and `<subdomain>.prd01.xyz.com`

Example config:
```
"Domain": {
    "baseDomain": "prd01.xyz.com"
}
```

The previous approach would treat `<subdomain>.prd01` as the subdomain rather than just the `<subdomain>` part.